### PR TITLE
Codacy fixes

### DIFF
--- a/environment/getter.c
+++ b/environment/getter.c
@@ -39,10 +39,12 @@ char *get_environment_variable(envvar_t **env, char *var)
 
 char *get_variable_name(char *args)
 {
+    if (args == NULL)
+        return NULL;
     int vlen = 0;
     for (; args[vlen] != 0 && args[vlen] != 32 && args[vlen] != 10; vlen++);
     char *varname = malloc(sizeof(char) * (vlen + 1) + 1);
-    if (varname == NULL || vlen == 0 || args == NULL)
+    if (varname == NULL || vlen == 0)
         return (NULL);
     strncpy(varname, args, vlen);
     varname[vlen] = 0;

--- a/history/show_history.c
+++ b/history/show_history.c
@@ -42,7 +42,7 @@ void show_file_history(history_t *history)
         char *line = strdup(buf + (strlen(buf) - get_line_len(buf)));
         char *strdate = ctime(&time), *ret = strchr(strdate, '\n');
         *ret = 0;
-        printf("%i\t%s\t%s", i + 1, strdate, line + 1);
+        printf("%u\t%s\t%s", i + 1, strdate, line + 1);
         free(buf);
         free(line);
     }

--- a/shell.c
+++ b/shell.c
@@ -64,7 +64,8 @@ char *read_stdin(void)
         total += read;
         if (total == size) {
             size *= 2;
-            buffer = realloc(buffer, size);
+            char *tmpbuf = realloc(buffer, size);
+            buffer = (tmpbuf) ? tmpbuf : buffer;
         }
     }
     buffer[total] = '\0';


### PR DESCRIPTION
Fixed codacy issues
fix: %i in format string (no. 1) requires 'int' but the argument type is 'unsigned int'.
fix: Either the condition 'args==NULL' is redundant or there is possible null pointer dereference: args.
 fix: Common realloc mistake: 'buffer' nulled but not freed upon failure